### PR TITLE
feat(auth): add auth from browser context

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -26,7 +26,7 @@
         "python.formatting.autopep8Path": "/usr/local/py-utils/bin/autopep8",
         "python.linting.pylintPath": "/usr/local/py-utils/bin/pylint",
         "python.testing.pytestArgs": [
-            "pollination_streamlit/tests",
+            "tests",
             "-s"
         ],
         "python.testing.pytestEnabled": true,
@@ -43,7 +43,7 @@
     // Use 'forwardPorts' to make a list of ports inside the container available locally.
     // "forwardPorts": [],
     // Use 'postCreateCommand' to run commands after the container is created.
-    "postCreateCommand": "pip3 install --user -r pollination_streamlit/requirements.txt -r pollination_streamlit/dev-requirements.txt",
+    "postCreateCommand": "pip3 install --user -r requirements.txt -r dev-requirements.txt",
     // Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
     "remoteUser": "vscode"
 }

--- a/pollination_streamlit/api/client.py
+++ b/pollination_streamlit/api/client.py
@@ -11,12 +11,13 @@ DEFAULT_HOST = 'https://api.pollination.cloud'
 
 class ApiClient():
 
-    def __init__(self, host: str = DEFAULT_HOST, api_token: str = None):
+    def __init__(self, host: str = DEFAULT_HOST, api_token: str = None, jwt_token: str = None):
         if host[-1] == '/':
             host = host[:-1]
 
         self._host = host
         self.api_token = api_token
+        self.jwt_token = jwt_token
 
     @property
     def host(self) -> str:
@@ -27,6 +28,10 @@ class ApiClient():
         if self.api_token is not None:
             return {
                 'x-pollination-token': self.api_token
+            }
+        elif self.jwt_token is not None:
+            return {
+                'Authorization': f'Bearer {self.jwt_token}'
             }
         return {}
 

--- a/pollination_streamlit/authentication.py
+++ b/pollination_streamlit/authentication.py
@@ -1,0 +1,44 @@
+import base64
+import os
+import re
+import typing as t
+
+import extra_streamlit_components as stx
+import streamlit as st
+
+COOKIE_NAME = os.getenv('COOKIE_NAME', 'pollination-authz')
+
+
+@st.cache(allow_output_mutation=True)
+def get_manager():
+    return stx.CookieManager()
+
+
+def _decode_base64(data, altchars=b'+/'):
+    """Decode base64, padding being optional.
+
+    :param data: Base64 data as an ASCII byte string
+    :returns: The decoded byte string.
+
+    """
+    data = re.sub(rb'[^a-zA-Z0-9%s]+' % altchars, b'', data)  # normalize
+    missing_padding = len(data) % 4
+    if missing_padding:
+        data += b'=' * (4 - missing_padding)
+    return base64.b64decode(data, altchars)
+
+
+def _decrypt_cookie(cookie: str):
+    b64_bytes = _decode_base64(str.encode(cookie))
+    parts = b64_bytes.split(b'|')
+    value = parts[1]
+    token_bytes = _decode_base64(value)
+    return token_bytes.decode('utf-8')
+
+
+def get_jwt_from_browser() -> t.Optional[str]:
+    cookies = get_manager().get_all()
+    cookie = cookies.get(COOKIE_NAME)
+    if cookie is None:
+        return cookie
+    return _decrypt_cookie(cookie)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 streamlit>=1.2.0
+extra-streamlit-components>=0.1.53
 requests
 queenbee

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -1,0 +1,7 @@
+from pollination_streamlit.authentication import _decrypt_cookie
+
+
+def test_decrypt():
+    cookie = "MTY0NzUyMTM2M3xjM1Z3WlhJdGMyVmpjbVYwTFhaaGJIVmx8Zq5Ks3q90QdgL5znATZfz5LsGWUcSc5CGIOeZn-EQBE="
+    value = "super-secret-value"
+    assert _decrypt_cookie(cookie) == value


### PR DESCRIPTION
fix #4

This PR changes the way we generate an authenticated API client. Instead of fetching an api key and then injecting it as an argument to "job_selector" we use the `get_api_client` method to automatically load the JWT token from cookies or ask for an API token.

Here is an example app with a short video demonstrating what it looks like with and without a valid cookie saved:

```python
import streamlit as st

from pollination_streamlit.selectors import get_api_client, job_selector

st.set_page_config(
    page_title='Daylight Factor App', layout='wide',
    page_icon='https://app.pollination.cloud/favicon.ico'
)

# branding, api-key and url
# we should wrap this up as part of the pollination-streamlit library
st.sidebar.image(
    'https://uploads-ssl.webflow.com/6035339e9bb6445b8e5f77d7/616da00b76225ec0e4d975ba_pollination_brandmark-p-500.png',
    use_column_width=True
)

client = get_api_client(st.sidebar)


job = job_selector(
    client, default='https://app.staging.pollination.cloud/ladybug-tools/projects/multiphase-recipes/jobs/a24de002-63df-435e-8dcf-0263adb5497e')

if job is not None:
    st.text("Fetched Job!")

```

https://user-images.githubusercontent.com/20436635/158836620-8b1de013-a6a2-4948-91f8-e3d44517f665.mp4
