### PR TITLE
feat(contex): use app auth proxy and env vars for extra context

### DIFF
--- a/pollination_streamlit/api/client.py
+++ b/pollination_streamlit/api/client.py
@@ -1,12 +1,11 @@
+import os
 import typing as t
 from io import BytesIO
 
 import requests
-from requests import Session
 
-# from ._client_base import ClientBase as Client
-
-DEFAULT_HOST = 'https://api.pollination.cloud'
+DEFAULT_HOST = os.getenv('POLLINATION_API_URL',
+                         'https://api.pollination.cloud')
 
 
 class ApiClient():
@@ -37,7 +36,7 @@ class ApiClient():
 
     @property
     def session(self):
-        s = Session()
+        s = requests.Session()
         s.headers = self.headers
         return s
 

--- a/pollination_streamlit/authentication.py
+++ b/pollination_streamlit/authentication.py
@@ -4,9 +4,11 @@ import re
 import typing as t
 
 import extra_streamlit_components as stx
+import requests
 import streamlit as st
 
 COOKIE_NAME = os.getenv('COOKIE_NAME', 'pollination-authz')
+PROXY_URL = os.getenv('PROXY_URL', 'http://localhost:8000')
 
 
 @st.cache(allow_output_mutation=True)
@@ -36,9 +38,52 @@ def _decrypt_cookie(cookie: str):
     return token_bytes.decode('utf-8')
 
 
+def _get_jwt_from_auth_proxy(cookie: str) -> str:
+    """Get the logged in user JWT
+
+    Returns:
+    str: The base64 encoded user JWT
+    """
+    res = requests.get(
+        f'{PROXY_URL}/auth/jwt',
+        cookies={
+            COOKIE_NAME: cookie
+        }
+    )
+    res.raise_for_status()
+    return res.text
+
+
 def get_jwt_from_browser() -> t.Optional[str]:
+    """Get and decrypt the auth cookie
+
+    Deprecated: this method is not as reliable as the get_jwt method if app auth proxy is v0.5.0 or more
+
+    Returns:
+        t.Optional[str]: The decrypted auth cookie if it exists
+    """
     cookies = get_manager().get_all()
     cookie = cookies.get(COOKIE_NAME)
     if cookie is None:
         return cookie
     return _decrypt_cookie(cookie)
+
+
+def get_jwt() -> t.Optional[str]:
+    """Get and decrypt the logged in user's JWT
+
+    Returns:
+        t.Optional[str]: The decrypted auth cookie if it exists
+    """
+    cookies = get_manager().get_all()
+    cookie = cookies.get(COOKIE_NAME)
+    if cookie is None:
+        return None
+    try:
+        return _get_jwt_from_auth_proxy(cookie)
+    except requests.HTTPError:
+        print(
+            "Error fetching JWT from /auth/jwt endpoint. Defaulting to cookie decryption.")
+        # Fallback to default cookie decryption technique if not using
+        # app-auth-proxy > v0.5.0
+        return _decrypt_cookie(cookie)


### PR DESCRIPTION
* Load JWT by hitting `/auth/jwt` endpoint on app auth proxy
* Get Pollination API endpoint from env vars as per https://github.com/pollination/pollination-server/pull/645/commits/cc9302fa99e4d10625fbea8dde70536fa192421a