### PR TITLE
feat(client): add auth check property

### DIFF
--- a/pollination_streamlit/api/client.py
+++ b/pollination_streamlit/api/client.py
@@ -19,6 +19,38 @@ class ApiClient():
         self.jwt_token = jwt_token
 
     @property
+    def api_token(self) -> str:
+        return self._api_token
+
+    @api_token.setter
+    def api_token(self, value):
+        self._api_token = self._validate_string_input(value)
+
+    @property
+    def jwt_token(self) -> str:
+        return self._jwt_token
+
+    @jwt_token.setter
+    def jwt_token(self, value):
+        self._jwt_token = self._validate_string_input(value)
+
+    @staticmethod
+    def _validate_string_input(value) -> str:
+        if isinstance(value, str):
+            if len(value) == 0:
+                return None
+            else:
+                return value
+        if value is None:
+            return value
+        raise ValueError(
+            f'Expected instance of type str but got: {type(value)}')
+
+    @property
+    def is_authenticated(self) -> bool:
+        return self.api_token is not None or self.jwt_token is not None
+
+    @property
     def host(self) -> str:
         return self._host
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -94,3 +94,16 @@ def test_get_recipe(recipes_api: RecipesAPI, get_recipe, recipe):
 
 def test_get_auth_user(user_api: UserApi, get_user, user_profile):
     assert user_api.get_user() == user_profile
+
+
+@pytest.mark.parametrize('api_token,jwt,expected', [
+    ('', '', False),
+    ('foo', None, True),
+    (None, 'jwt-token-string', True),
+    (None, '', False),
+    (None, None, False),
+])
+def test_is_authenticated(test_client: ApiClient, api_token, jwt, expected):
+    test_client.api_token = api_token
+    test_client.jwt_token = jwt
+    assert test_client.is_authenticated == expected


### PR DESCRIPTION
This PR adds a helpful property to the API client to determine whether it is an authenticated client.

Here is an example use case were we require an authenticated client or we will encounter an API error because the `AuthUser` class fetches the currently authenticated user and returns a `403` if no auth headers are found:

```python
import streamlit as st

from pollination_streamlit.selectors import get_api_client
from pollination_streamlit.interactors import AuthUser


st.write("Welcome! Start writing your Pollination app here.")

client = get_api_client()

if client.is_authenticated:
    user = AuthUser(client)
    st.write(f'Hi {user.name}! Your API client is pointing at {client.host}')
```