### PR TITLE
fix(requirements): enforce version to be smaller than 1.17.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-streamlit>=1.2.0
+streamlit<=1.17.0
 extra-streamlit-components>=0.1.53
 requests
 queenbee


### PR DESCRIPTION
This is important to avoid the recent socket timeout issue in Streamlit