### PR TITLE
feat(auth): add api token auth and make client fetching more flexible

### DIFF
--- a/pollination_streamlit/authentication.py
+++ b/pollination_streamlit/authentication.py
@@ -1,17 +1,46 @@
 import base64
 import os
 import typing as t
+import re
 
-import extra_streamlit_components as stx
 import requests
-import streamlit as st
+import extra_streamlit_components as stx
+from .api.client import ApiClient
 
 COOKIE_NAME = os.getenv('COOKIE_NAME', 'pollination-authz')
 PROXY_URL = os.getenv('PROXY_URL', 'http://localhost:8000')
-
+AUTH_PROXY_VERSION = os.getenv('AUTH_PROXY_VERSION', 'v0.5.5')
 
 def get_manager():
     return stx.CookieManager()
+
+def _auth_proxy_major_version() -> int:
+    """Get the major version of app-auth-proxy
+
+    Returns:
+        int: The major version of app-auth-proxy
+    """
+    match = re.match(r'v?(\d+)\.\d+\.\d+', AUTH_PROXY_VERSION)
+    if match:
+        return int(match.group(1))
+    else:
+        raise ValueError(f"Invalid version: {AUTH_PROXY_VERSION}")
+
+def get_api_client() -> ApiClient:
+    """Get an authenticated API client
+
+    Returns:
+        ApiClient: An authenticated API client
+    """
+
+    client = ApiClient()
+
+    if _auth_proxy_major_version() < 1:
+        client.jwt_token = get_jwt()
+    else:
+        client.api_token = get_api_token()
+
+    return client
 
 
 def _decode_base64(data):
@@ -46,21 +75,20 @@ def _get_jwt_from_auth_proxy(cookie: str) -> str:
     res.raise_for_status()
     return res.text
 
-
-def get_jwt_from_browser() -> t.Optional[str]:
-    """Get and decrypt the auth cookie
-
-    Deprecated: this method is not as reliable as the get_jwt method if app auth proxy is v0.5.0 or more
+def _get_api_token_from_auth_proxy(cookie: str) -> str:
+    """Get the logged in user JWT
 
     Returns:
-        t.Optional[str]: The decrypted auth cookie if it exists
+    str: The base64 encoded user JWT
     """
-    cookies = get_manager().get_all()
-    cookie = cookies.get(COOKIE_NAME)
-    if cookie is None:
-        return cookie
-    return _decrypt_cookie(cookie)
-
+    res = requests.get(
+        f'{PROXY_URL}/auth/api-token',
+        cookies={
+            COOKIE_NAME: cookie
+        }
+    )
+    res.raise_for_status()
+    return res.text
 
 def get_jwt() -> t.Optional[str]:
     """Get and decrypt the logged in user's JWT
@@ -82,3 +110,16 @@ def get_jwt() -> t.Optional[str]:
         # Fallback to default cookie decryption technique if not using
         # app-auth-proxy > v0.5.0
         return _decrypt_cookie(cookie)
+
+
+def get_api_token() -> t.Optional[str]:
+    """Get and decrypt the logged in user's JWT
+
+    Returns:
+        t.Optional[str]: The decrypted auth cookie if it exists
+    """
+    cookies = get_manager().get_all()
+    cookie = cookies.get(COOKIE_NAME)
+    if cookie is None:
+        return None
+    return _get_api_token_from_auth_proxy(cookie)

--- a/pollination_streamlit/selectors.py
+++ b/pollination_streamlit/selectors.py
@@ -1,30 +1,27 @@
 import streamlit as st
-import binascii
 
 from .api.client import ApiClient
-from .authentication import get_jwt
+from .authentication import get_api_client as _get_api_client
 from .interactors import Job, Run
 
 
 def get_api_client(st_element: st = st) -> ApiClient:
-    client = ApiClient()
-    try:
-        client.jwt_token = get_jwt()
-    except binascii.Error:
-        client.jwt_token = None
+
+    client = _get_api_client()
+
+    if not client.is_authenticated:
         st.warning(
             'The app failed to find your Pollination account information. '
             'Try to refresh the page! If that did not solve the problem, try using '
             'a Pollination API key.'
         )
-
-    if client.jwt_token is None:
         client.api_token = st_element.text_input(
             'Enter Pollination APIKEY', type='password',
             help=':bulb: You only need an API Key to access private projects. '
             'If you do not have a key already go to the settings tab under your '
             'profile to generate one.'
         )
+
     return client
 
 


### PR DESCRIPTION
I have abstracted away the details of whether the app should use JWT or API Token auth by using the underlying app-auth-proxy version environment variable which should be loaded into all applications going forward. This will make it easier for end users to migrate to the new authentication method by simply upgrading to the new version of pollination-streamlit. The fetching new api client method remains the same.